### PR TITLE
Update comm_unity.py

### DIFF
--- a/src/virtualhome/simulation/unity_simulator/comm_unity.py
+++ b/src/virtualhome/simulation/unity_simulator/comm_unity.py
@@ -1,6 +1,6 @@
 
 import base64
-import collections
+import collections.abc as collections
 import time
 import io
 import json


### PR DESCRIPTION
Fixed an issue with an import (collections) that now is deprecated. Used collections.abc instead of collections.